### PR TITLE
Make dagmc optional

### DIFF
--- a/pyne/CMakeLists.txt
+++ b/pyne/CMakeLists.txt
@@ -49,14 +49,14 @@ install(TARGETS cram LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/pyne")
 #
 # dagmc requires a rename and is only built if we have MOAB.
 #
-if(MOAB_FOUND)
+if(DAGMC_FOUND)
   set_source_files_properties("${PROJECT_SOURCE_DIR}/pyne/dagmc.pyx"
                               PROPERTIES CYTHON_IS_CXX TRUE)
   cython_add_module(_dagmc dagmc.pyx "${PROJECT_SOURCE_DIR}/src/dagmc_bridge.cpp")
   target_link_libraries(_dagmc dagmc MOAB pyne)
   set_target_properties(_dagmc PROPERTIES OUTPUT_NAME dagmc)
   install(TARGETS _dagmc LIBRARY DESTINATION "${PYTHON_SITE_PACKAGES}/pyne")
-endif(MOAB_FOUND)
+endif(DAGMC_FOUND)
 
 #
 # Spatial Solver

--- a/setup.py
+++ b/setup.py
@@ -271,8 +271,7 @@ def update_cmake_args(ns):
         ]
     if ns.moab is not None:
         ns.cmake_args.append('-DMOAB_ROOT=' + absexpanduser(ns.moab))
-        assert ns.dagmc is not None, "If the --moab option is present," \
-                                     " --dagmc must be as well"
+
     if ns.dagmc is not None:
         ns.cmake_args.append('-DDAGMC_ROOT=' + absexpanduser(ns.dagmc))
         assert ns.moab is not None, "If the --dagmc option is present," \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,8 +93,11 @@ IF(BUILD_SPATIAL_SOLVER)
     target_link_libraries(pyne ${LIBS_HDF5} ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
 ENDIF(BUILD_SPATIAL_SOLVER)
 if(MOAB_FOUND)
-    target_link_libraries(pyne dagmc MOAB)
+    target_link_libraries(pyne MOAB)
 endif(MOAB_FOUND)
+if(DAGMC_FOUND)
+    target_link_libraries(pyne dagmc MOAB)
+endif(DAGMC_FOUND)
 
 add_executable(alphad ${PROJECT_SOURCE_DIR}/src/ensdf_processing/ALPHAD/alphad.f
                       ${PROJECT_SOURCE_DIR}/src/ensdf_processing/nsdflib95.f)


### PR DESCRIPTION
Tweak the build scripts to allow DAGMC to be optional, separately from MOAB.

This builds cleanly, and passes all tests except for some tests that are skipped because of failure to import `dagmc`.  This seems like the right behavior.

Fixes #15 