### PR TITLE
Add delete tag

### DIFF
--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -995,6 +995,12 @@ class Mesh(object):
     def get_tag(self, tag_name):
         return getattr(self, tag_name)
 
+    def delete_tag(self, tag_name):
+        # delete Tag object
+        # remove from list of tags
+        # delattr
+        pass
+    
     def __iadd__(self, other):
         """Adds the common tags of other to the mesh object.
         """

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -9,6 +9,7 @@ from pyne.utils import QAWarning
 import numpy as np
 import tables as tb
 
+
 warn(__name__ + " is not yet QA compliant.", QAWarning)
 
 try:
@@ -104,7 +105,12 @@ class Tag(object):
         del self.mesh.tags[self.name]
         del self[:]
 
-
+    def delete(self, mesh=None):
+        if mesh == None:
+            mesh = self.mesh
+        del self[:]
+        del mesh.tags[self.name]
+        
 class MaterialPropertyTag(Tag):
     """A mesh tag which looks itself up as a material property (attribute).
     This makes the following expressions equivalent for a given material property
@@ -391,6 +397,13 @@ class NativeMeshTag(Tag):
         super(NativeMeshTag, self).__delete__(mesh)
         self.mesh.mesh.tag_delete(self.tag)
 
+    def delete(self,mesh=None):
+        if mesh == None:
+            mesh = self.mesh
+        super(NativeMeshTag, self).delete()
+        mesh.mesh.tag_delete(self.tag)
+
+        
     def __getitem__(self, key):
         m = self.mesh.mesh
         size = len(self.mesh)
@@ -999,15 +1012,16 @@ class Mesh(object):
     def delete_tag(self, tag):
         if isinstance(tag,Tag):
             tag_name = tag.name
+            tag_handle = tag
         elif isinstance(tag, str):
             tag_name = tag
+            tag_handle = self.tags[tag_name]
         else:
             raise ValueError('{0} is neither a Tag object nor a string'.format(tag))
 
+        tag_handle.delete()
+
         if hasattr(self, tag_name):
-            # must remove both references to the tag object for
-            # it to be deleted
-            del self.tags[tag_name]
             delattr(self, tag_name)
     
     def __iadd__(self, other):

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -996,11 +996,19 @@ class Mesh(object):
     def get_tag(self, tag_name):
         return getattr(self, tag_name)
 
-    def delete_tag(self, tag_name):
-        # must remove both references to the tag object for
-        # it to be deleted
-        del self.tags[tag_name]
-        delattr(self, tag_name)
+    def delete_tag(self, tag):
+        if isinstance(tag,Tag):
+            tag_name = tag.name
+        elif isinstance(tag, str):
+            tag_name = tag
+        else:
+            raise ValueError('{0} is neither a Tag object nor a string'.format(tag))
+
+        if hasattr(self, tag_name):
+            # must remove both references to the tag object for
+            # it to be deleted
+            del self.tags[tag_name]
+            delattr(self, tag_name)
     
     def __iadd__(self, other):
         """Adds the common tags of other to the mesh object.

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -102,7 +102,7 @@ class Tag(object):
         self[:] = value[:]
 
     def __delete__(self, mesh):
-        del self.mesh.tags[self.name]
+        del mesh.tags[self.name]
         del self[:]
 
     def delete(self, mesh=None):
@@ -395,7 +395,7 @@ class NativeMeshTag(Tag):
 
     def __delete__(self, mesh):
         super(NativeMeshTag, self).__delete__(mesh)
-        self.mesh.mesh.tag_delete(self.tag)
+        mesh.mesh.tag_delete(self.tag)
 
     def delete(self,mesh=None):
         if mesh == None:

--- a/pyne/mesh.py
+++ b/pyne/mesh.py
@@ -101,6 +101,7 @@ class Tag(object):
         self[:] = value[:]
 
     def __delete__(self, mesh):
+        del self.mesh.tags[self.name]
         del self[:]
 
 
@@ -388,7 +389,7 @@ class NativeMeshTag(Tag):
 
     def __delete__(self, mesh):
         super(NativeMeshTag, self).__delete__(mesh)
-        self.mesh.mesh.tag_delete(self.name)
+        self.mesh.mesh.tag_delete(self.tag)
 
     def __getitem__(self, key):
         m = self.mesh.mesh
@@ -996,10 +997,10 @@ class Mesh(object):
         return getattr(self, tag_name)
 
     def delete_tag(self, tag_name):
-        # delete Tag object
-        # remove from list of tags
-        # delattr
-        pass
+        # must remove both references to the tag object for
+        # it to be deleted
+        del self.tags[tag_name]
+        delattr(self, tag_name)
     
     def __iadd__(self, other):
         """Adds the common tags of other to the mesh object.

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -682,6 +682,8 @@ def test_del_nativetag():
     m.f = NativeMeshTag(mesh=m, name='f')
     m.f[:] = [1.0, 2.0, 3.0, 4.0]
 
+    assert_raises(ValueError, m.delete_tag,-12)
+
     import sys
 
     # make a new reference to the tag that can will not
@@ -696,6 +698,7 @@ def test_del_nativetag():
     # 2. is the one that automatically is the temporary
     #    reference created as the argument to getrefcount
     assert_equal(2,sys.getrefcount(tag_ref))
+    
 
 def test_nativetag_fancy_indexing():
     m = gen_mesh()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -688,7 +688,7 @@ def test_del_nativetag():
 
     import sys
 
-    # make a new reference to the tag that can will not
+    # make a new reference to the tag that will not
     # be deleted
     tag_ref = m.f
 
@@ -701,13 +701,14 @@ def test_del_nativetag():
     #    reference created as the argument to getrefcount
     assert_equal(2,sys.getrefcount(tag_ref))
 
-    
+    assert_raises(RuntimeError,m.mesh.tag_get_handle,'f')
+
     # deleting tag by tag handle
     tag_ref = m.g
     m.delete_tag(m.g)
     assert_equal(2,sys.getrefcount(tag_ref))
     
-    
+    assert_raises(RuntimeError,m.mesh.tag_get_handle,'g')
     
 def test_nativetag_fancy_indexing():
     m = gen_mesh()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -7,7 +7,8 @@ import warnings
 import itertools
 from operator import itemgetter
 from nose.tools import assert_true, assert_equal, assert_raises, with_setup, \
-    assert_is, assert_is_instance, assert_in, assert_not_in, assert_almost_equal
+    assert_is, assert_is_instance, assert_in, assert_not_in, assert_almost_equal, \
+    assert_is_none, assert_is_not_none, assert_false
 
 import numpy as np
 from numpy.testing import assert_array_equal, assert_array_almost_equal
@@ -669,6 +670,32 @@ def test_nativetag():
 
     # deleting tag
     del m.f[:]
+
+def test_del_nativetag():
+    mats = {
+        0: Material({'H1': 1.0, 'K39': 1.0}, density=42.0),
+        1: Material({'H1': 0.1, 'O16': 1.0}, density=43.0),
+        2: Material({'He4': 42.0}, density=44.0),
+        3: Material({'Tm171': 171.0}, density=45.0),
+        }
+    m = gen_mesh(mats=mats)
+    m.f = NativeMeshTag(mesh=m, name='f')
+    m.f[:] = [1.0, 2.0, 3.0, 4.0]
+
+    import sys
+
+    # make a new reference to the tag that can will not
+    # be deleted
+    tag_ref = m.f
+
+    # deleting tag
+    m.delete_tag('f')
+
+    # ensure that there are only 2 references to this tag
+    # 1. is the tag_ref created above
+    # 2. is the one that automatically is the temporary
+    #    reference created as the argument to getrefcount
+    assert_equal(2,sys.getrefcount(tag_ref))
 
 def test_nativetag_fancy_indexing():
     m = gen_mesh()

--- a/tests/test_mesh.py
+++ b/tests/test_mesh.py
@@ -681,6 +681,8 @@ def test_del_nativetag():
     m = gen_mesh(mats=mats)
     m.f = NativeMeshTag(mesh=m, name='f')
     m.f[:] = [1.0, 2.0, 3.0, 4.0]
+    m.g = NativeMeshTag(mesh=m, name='g')
+    m.g[:] = [1.0, 2.0, 3.0, 4.0]
 
     assert_raises(ValueError, m.delete_tag,-12)
 
@@ -690,7 +692,7 @@ def test_del_nativetag():
     # be deleted
     tag_ref = m.f
 
-    # deleting tag
+    # deleting tag by tag name
     m.delete_tag('f')
 
     # ensure that there are only 2 references to this tag
@@ -698,8 +700,15 @@ def test_del_nativetag():
     # 2. is the one that automatically is the temporary
     #    reference created as the argument to getrefcount
     assert_equal(2,sys.getrefcount(tag_ref))
-    
 
+    
+    # deleting tag by tag handle
+    tag_ref = m.g
+    m.delete_tag(m.g)
+    assert_equal(2,sys.getrefcount(tag_ref))
+    
+    
+    
 def test_nativetag_fancy_indexing():
     m = gen_mesh()
 


### PR DESCRIPTION
Fixes #26 

Since creating a tag makes two references to that object, both need to be deleted to correctly remove a Tag.  This addition adds `delete_tag` to the `Mesh` class that will accomplish this.