### PR TITLE
compatibility of configparser

### DIFF
--- a/scripts/r2s.py
+++ b/scripts/r2s.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python
 import argparse
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
+
 from os.path import isfile
 
 from pyne.mesh import Mesh


### PR DESCRIPTION
When we use pymoab to replace pytabs, we can use python3. The ConfigParser (in python2) is called configparser (in python3).