### PR TITLE
Add input check ebins

### DIFF
--- a/src/source_sampling.cpp
+++ b/src/source_sampling.cpp
@@ -59,6 +59,9 @@ std::vector<double> pyne::read_e_bounds(std::string e_bounds_file){
     while (inputFile >> value)
       e_bounds.push_back(value);
   }
+  else {
+    throw std::invalid_argument("File e_bounds not found or no read permission");
+  }
   return e_bounds;
 }
 


### PR DESCRIPTION
There are four input files for r2s photon transport (input, geom.h5m, source.h5m and e_bounds). Users sometimes forget to put `e_bounds` in the working directory and therefore cause a segmentation fault without the message of missing `e_bounds`.

This PR adds the error message when the `e_bounds` is missing (or no read permission).

There are already error messages for all of the other three input files (input, geom.h5m, source.h5m).